### PR TITLE
setting up party rockers and listening sessions in back end

### DIFF
--- a/server/src/db/sql.ts
+++ b/server/src/db/sql.ts
@@ -1,6 +1,8 @@
 import { createPool, PoolConnection, QueryOptions } from 'mysql2'
 import { createConnection } from 'typeorm'
 import { Artist } from '../entities/Artist'
+import { ListeningSession } from '../entities/ListeningSession'
+import { PartyRocker } from '../entities/PartyRocker'
 import { Session } from '../entities/Session'
 import { Song } from '../entities/Song'
 import { Survey } from '../entities/Survey'
@@ -22,7 +24,7 @@ export async function initORM() {
     username: process.env.MYSQL_USER || 'root',
     synchronize: true,
     logging: false,
-    entities: [User, Artist, Song, Session, Survey, SurveyQuestion, SurveyAnswer],
+    entities: [User, Artist, Song, Session, ListeningSession, PartyRocker, Survey, SurveyQuestion, SurveyAnswer],
     extra: {
       connectionLimit: 5,
     },

--- a/server/src/entities/ListeningSession.ts
+++ b/server/src/entities/ListeningSession.ts
@@ -1,0 +1,19 @@
+import { BaseEntity, CreateDateColumn, Entity, OneToMany, OneToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { PartyRocker } from './PartyRocker'
+
+@Entity()
+export class ListeningSession extends BaseEntity {
+  @PrimaryGeneratedColumn()
+  id: number
+
+  //time created is time since epoch
+  @CreateDateColumn()
+  timeCreated: number
+
+  @OneToOne(type => PartyRocker)
+  owner: PartyRocker
+
+  @OneToMany(type => PartyRocker, partyRocker => partyRocker.listeningSession)
+  partyRockers: PartyRocker[]
+
+}

--- a/server/src/entities/PartyRocker.ts
+++ b/server/src/entities/PartyRocker.ts
@@ -1,0 +1,24 @@
+import { BaseEntity, Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
+import { ListeningSession } from './ListeningSession'
+
+//currently user just copied from his code but change this to be our user. I didnt wanna delete his user file and break code
+
+@Entity()
+export class PartyRocker extends BaseEntity {
+
+  @PrimaryGeneratedColumn()
+  id: number
+
+  @Column({
+    length: 50,
+  })
+  name: string
+
+  @Column({nullable:true})
+  spotifyCreds: string
+
+  @ManyToOne(type => ListeningSession, listeningSession => listeningSession.partyRockers)
+  listeningSession: ListeningSession
+
+
+}

--- a/server/src/graphql/api.ts
+++ b/server/src/graphql/api.ts
@@ -2,6 +2,7 @@ import { readFileSync } from 'fs'
 import { PubSub } from 'graphql-yoga'
 import path from 'path'
 import { check } from '../../../common/src/util'
+import { ListeningSession } from '../entities/ListeningSession'
 import { Survey } from '../entities/Survey'
 import { SurveyAnswer } from '../entities/SurveyAnswer'
 import { SurveyQuestion } from '../entities/SurveyQuestion'
@@ -26,6 +27,7 @@ export const graphqlRoot: Resolvers<Context> = {
   Query: {
     self: (_, args, ctx) => ctx.user,
     survey: async (_, { surveyId }) => (await Survey.findOne({ where: { id: surveyId } })) || null,
+    listeningSession: async (_, { sessionId }) => (await ListeningSession.findOne({ where: { id: sessionId } })) || null,
     surveys: () => Survey.find(),
   },
   Mutation: {

--- a/server/src/graphql/schema.gen.json
+++ b/server/src/graphql/schema.gen.json
@@ -961,6 +961,33 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "listeningSession",
+            "description": null,
+            "args": [
+              {
+                "name": "sessionId",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ListeningSession",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1316,6 +1343,156 @@
                   "ofType": null
                 }
               }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "ListeningSession",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "timeCreated",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "owner",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "OBJECT",
+                "name": "PartyRocker",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "partyRockers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PartyRocker",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "enumValues": null,
+        "possibleTypes": null
+      },
+      {
+        "kind": "OBJECT",
+        "name": "PartyRocker",
+        "description": null,
+        "fields": [
+          {
+            "name": "id",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Int",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "name",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "spotifyCreds",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "listeningSession",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "OBJECT",
+              "name": "ListeningSession",
+              "ofType": null
             },
             "isDeprecated": false,
             "deprecationReason": null

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -21,6 +21,7 @@ type Query {
   surveys: [Survey!]!
   survey(surveyId: Int!): Survey
   artist(name: String!): Artist
+  listeningSession(sessionId: Int!): ListeningSession
 }
 
 type Mutation {
@@ -55,6 +56,21 @@ type Artist {
   name: String!
   origin: String
   songs: [Song]!
+}
+
+#time created is time since epoch
+type ListeningSession {
+  id: Int!
+  timeCreated: Int!
+  owner: PartyRocker!
+  partyRockers: [PartyRocker!]!
+}
+
+type PartyRocker {
+  id: Int!
+  name: String!
+  spotifyCreds: String
+  listeningSession: ListeningSession
 }
 
 enum UserType {

--- a/server/src/graphql/schema.types.ts
+++ b/server/src/graphql/schema.types.ts
@@ -18,6 +18,7 @@ export interface Query {
   surveys: Array<Survey>
   survey?: Maybe<Survey>
   artist?: Maybe<Artist>
+  listeningSession?: Maybe<ListeningSession>
 }
 
 export interface QuerySurveyArgs {
@@ -26,6 +27,10 @@ export interface QuerySurveyArgs {
 
 export interface QueryArtistArgs {
   name: Scalars['String']
+}
+
+export interface QueryListeningSessionArgs {
+  sessionId: Scalars['Int']
 }
 
 export interface Mutation {
@@ -74,6 +79,22 @@ export interface Artist {
   name: Scalars['String']
   origin?: Maybe<Scalars['String']>
   songs: Array<Maybe<Song>>
+}
+
+export interface ListeningSession {
+  __typename?: 'ListeningSession'
+  id: Scalars['Int']
+  timeCreated: Scalars['Int']
+  owner: PartyRocker
+  partyRockers: Array<PartyRocker>
+}
+
+export interface PartyRocker {
+  __typename?: 'PartyRocker'
+  id: Scalars['Int']
+  name: Scalars['String']
+  spotifyCreds?: Maybe<Scalars['String']>
+  listeningSession?: Maybe<ListeningSession>
 }
 
 export enum UserType {
@@ -198,6 +219,8 @@ export type ResolversTypes = {
   User: ResolverTypeWrapper<User>
   Song: ResolverTypeWrapper<Song>
   Artist: ResolverTypeWrapper<Artist>
+  ListeningSession: ResolverTypeWrapper<ListeningSession>
+  PartyRocker: ResolverTypeWrapper<PartyRocker>
   UserType: UserType
   Survey: ResolverTypeWrapper<Survey>
   SurveyQuestion: ResolverTypeWrapper<SurveyQuestion>
@@ -216,6 +239,8 @@ export type ResolversParentTypes = {
   User: User
   Song: Song
   Artist: Artist
+  ListeningSession: ListeningSession
+  PartyRocker: PartyRocker
   Survey: Survey
   SurveyQuestion: SurveyQuestion
   SurveyAnswer: SurveyAnswer
@@ -235,6 +260,12 @@ export type QueryResolvers<
     RequireFields<QuerySurveyArgs, 'surveyId'>
   >
   artist?: Resolver<Maybe<ResolversTypes['Artist']>, ParentType, ContextType, RequireFields<QueryArtistArgs, 'name'>>
+  listeningSession?: Resolver<
+    Maybe<ResolversTypes['ListeningSession']>,
+    ParentType,
+    ContextType,
+    RequireFields<QueryListeningSessionArgs, 'sessionId'>
+  >
 }
 
 export type MutationResolvers<
@@ -302,6 +333,28 @@ export type ArtistResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType>
 }
 
+export type ListeningSessionResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['ListeningSession'] = ResolversParentTypes['ListeningSession']
+> = {
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
+  timeCreated?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
+  owner?: Resolver<ResolversTypes['PartyRocker'], ParentType, ContextType>
+  partyRockers?: Resolver<Array<ResolversTypes['PartyRocker']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
+export type PartyRockerResolvers<
+  ContextType = any,
+  ParentType extends ResolversParentTypes['PartyRocker'] = ResolversParentTypes['PartyRocker']
+> = {
+  id?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
+  name?: Resolver<ResolversTypes['String'], ParentType, ContextType>
+  spotifyCreds?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
+  listeningSession?: Resolver<Maybe<ResolversTypes['ListeningSession']>, ParentType, ContextType>
+  __isTypeOf?: IsTypeOfResolverFn<ParentType>
+}
+
 export type SurveyResolvers<
   ContextType = any,
   ParentType extends ResolversParentTypes['Survey'] = ResolversParentTypes['Survey']
@@ -344,6 +397,8 @@ export type Resolvers<ContextType = any> = {
   User?: UserResolvers<ContextType>
   Song?: SongResolvers<ContextType>
   Artist?: ArtistResolvers<ContextType>
+  ListeningSession?: ListeningSessionResolvers<ContextType>
+  PartyRocker?: PartyRockerResolvers<ContextType>
   Survey?: SurveyResolvers<ContextType>
   SurveyQuestion?: SurveyQuestionResolvers<ContextType>
   SurveyAnswer?: SurveyAnswerResolvers<ContextType>


### PR DESCRIPTION
added db entries and graphql types for party rockers and for listening sessions, added api endpoint fo listening sessions to query a session. generated resolvers for each. added listening session and party rocker entities in sql orm initialization 