### PR TITLE
Testing session fetch REDO 

### DIFF
--- a/server/src/db/migrations/V1.3__Add_survey_questions.sql
+++ b/server/src/db/migrations/V1.3__Add_survey_questions.sql
@@ -1,5 +1,5 @@
 
-insert into `survey_question` (`surveyId`, `prompt`, `choices`) values (1, '🧐 Robert was here!', '🤗,🙂,🙃,😴,😎,😳,😰');
+insert into `survey_question` (`surveyId`, `prompt`, `choices`) values (1, '🧐 How are you doing today?', '🤗,🙂,🙃,😴,😎,😳,😰');
 insert into `survey_question` (`surveyId`, `prompt`, `choices`) values (1, '😴 Is 8am too early for lecture?', 'yes,no');
 insert into `survey_question` (`surveyId`, `prompt`) values (1, '🌎 Where are you on the map?');
 insert into `survey_question` (`surveyId`, `prompt`) values (1, '🎓 What year in school are you?');

--- a/server/src/graphql/api.ts
+++ b/server/src/graphql/api.ts
@@ -3,6 +3,9 @@ import { PubSub } from 'graphql-yoga'
 import path from 'path'
 import { check } from '../../../common/src/util'
 import { ListeningSession } from '../entities/ListeningSession'
+import { PartyRocker } from '../entities/PartyRocker'
+import { Queue } from '../entities/Queue'
+import { Song } from '../entities/Song'
 import { Survey } from '../entities/Survey'
 import { SurveyAnswer } from '../entities/SurveyAnswer'
 import { SurveyQuestion } from '../entities/SurveyQuestion'
@@ -27,8 +30,11 @@ export const graphqlRoot: Resolvers<Context> = {
   Query: {
     self: (_, args, ctx) => ctx.user,
     survey: async (_, { surveyId }) => (await Survey.findOne({ where: { id: surveyId } })) || null,
-    listeningSession: async (_, { sessionId }) => (await ListeningSession.findOne({ where: { id: sessionId } })) || null,
+    listeningSession: async (_, { sessionId }) => (await ListeningSession.findOne({ where: { id: sessionId }, relations: ['queue'] })) || null,
+    sessionQueue: async (_, { sessionId }) => (await Queue.find({ where: { sessionId: sessionId } })) || null,
     surveys: () => Survey.find(),
+    partyRockers: async () => await PartyRocker.find(),
+    song: async (_, { songName }) => (await Song.find({ where: { name: songName } }))
   },
   Mutation: {
     answerSurvey: async (_, { input }, ctx) => {
@@ -59,5 +65,5 @@ export const graphqlRoot: Resolvers<Context> = {
       subscribe: (_, { surveyId }, context) => context.pubsub.asyncIterator('SURVEY_UPDATE_' + surveyId),
       resolve: (payload: any) => payload,
     },
-  },
+  }
 }

--- a/server/src/graphql/api.ts
+++ b/server/src/graphql/api.ts
@@ -34,7 +34,8 @@ export const graphqlRoot: Resolvers<Context> = {
     sessionQueue: async (_, { sessionId }) => (await Queue.find({ where: { sessionId: sessionId } })) || null,
     surveys: () => Survey.find(),
     partyRockers: async () => await PartyRocker.find(),
-    song: async (_, { songName }) => (await Song.find({ where: { name: songName } }))
+    songs: async () => await Song.find({relations: ['artist']}),
+    song: async (_, { songName }) => (await Song.find({ where: { name: songName }, relations: ['artist'] }))
   },
   Mutation: {
     answerSurvey: async (_, { input }, ctx) => {

--- a/server/src/graphql/schema.gen.json
+++ b/server/src/graphql/schema.gen.json
@@ -990,7 +990,7 @@
             "deprecationReason": null
           },
           {
-            "name": "queue",
+            "name": "sessionQueue",
             "description": null,
             "args": [
               {
@@ -1009,9 +1009,80 @@
               }
             ],
             "type": {
-              "kind": "OBJECT",
-              "name": "Queue",
-              "ofType": null
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Queue",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "partyRockers",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "PartyRocker",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "song",
+            "description": null,
+            "args": [
+              {
+                "name": "songName",
+                "description": null,
+                "type": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  }
+                },
+                "defaultValue": null
+              }
+            ],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Song",
+                  "ofType": null
+                }
+              }
             },
             "isDeprecated": false,
             "deprecationReason": null
@@ -1456,6 +1527,26 @@
             },
             "isDeprecated": false,
             "deprecationReason": null
+          },
+          {
+            "name": "queue",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "LIST",
+              "name": null,
+              "ofType": {
+                "kind": "NON_NULL",
+                "name": null,
+                "ofType": {
+                  "kind": "OBJECT",
+                  "name": "Queue",
+                  "ofType": null
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
           }
         ],
         "inputFields": null,
@@ -1519,6 +1610,18 @@
             "type": {
               "kind": "OBJECT",
               "name": "ListeningSession",
+              "ofType": null
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "foobazbar",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
               "ofType": null
             },
             "isDeprecated": false,

--- a/server/src/graphql/schema.gen.json
+++ b/server/src/graphql/schema.gen.json
@@ -1078,9 +1078,37 @@
                 "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Song",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Song",
+                    "ofType": null
+                  }
+                }
+              }
+            },
+            "isDeprecated": false,
+            "deprecationReason": null
+          },
+          {
+            "name": "songs",
+            "description": null,
+            "args": [],
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Song",
+                    "ofType": null
+                  }
                 }
               }
             },

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -25,6 +25,7 @@ type Query {
   sessionQueue(sessionId: Int!): [Queue!]! #return list of all songs in session queue
   partyRockers: [PartyRocker!]!
   song(songName: String!): [Song!]!
+  songs: [Song!]!
 }
 
 type Mutation {

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -22,7 +22,9 @@ type Query {
   survey(surveyId: Int!): Survey
   artist(name: String!): Artist
   listeningSession(sessionId: Int!): ListeningSession
-  queue(sessionId: Int!): Queue
+  sessionQueue(sessionId: Int!): [Queue!]! #return list of all songs in session queue
+  partyRockers: [PartyRocker!]!
+  song(songName: String!): [Song!]!
 }
 
 type Mutation {
@@ -31,6 +33,9 @@ type Mutation {
 
   # Moves the survey to the next question (or starts it if it hasn't started). ADMIN only.
   nextSurveyQuestion(surveyId: Int!): Survey
+
+  # #add song to master queue with currrent session id
+  # addToQueue()
 }
 
 type Subscription {
@@ -65,6 +70,7 @@ type ListeningSession {
   timeCreated: Int!
   owner: PartyRocker!
   partyRockers: [PartyRocker!]!
+  queue: [Queue!]
 }
 
 type PartyRocker {
@@ -72,6 +78,7 @@ type PartyRocker {
   name: String!
   spotifyCreds: String
   listeningSession: ListeningSession
+  foobazbar: String
 }
 
 type Queue {
@@ -132,3 +139,8 @@ input SurveyInput {
   questionId: Int!
   answer: String!
 }
+
+# input QueueInfo {
+#   song: Song!
+#   listeningSession: ListeningSession!
+# }

--- a/server/src/graphql/schema.types.ts
+++ b/server/src/graphql/schema.types.ts
@@ -19,7 +19,9 @@ export interface Query {
   survey?: Maybe<Survey>
   artist?: Maybe<Artist>
   listeningSession?: Maybe<ListeningSession>
-  queue?: Maybe<Queue>
+  sessionQueue: Array<Queue>
+  partyRockers: Array<PartyRocker>
+  song: Array<Maybe<Song>>
 }
 
 export interface QuerySurveyArgs {
@@ -34,8 +36,12 @@ export interface QueryListeningSessionArgs {
   sessionId: Scalars['Int']
 }
 
-export interface QueryQueueArgs {
+export interface QuerySessionQueueArgs {
   sessionId: Scalars['Int']
+}
+
+export interface QuerySongArgs {
+  songName: Scalars['String']
 }
 
 export interface Mutation {
@@ -92,6 +98,7 @@ export interface ListeningSession {
   timeCreated: Scalars['Int']
   owner: PartyRocker
   partyRockers: Array<PartyRocker>
+  queue?: Maybe<Array<Queue>>
 }
 
 export interface PartyRocker {
@@ -100,6 +107,7 @@ export interface PartyRocker {
   name: Scalars['String']
   spotifyCreds?: Maybe<Scalars['String']>
   listeningSession?: Maybe<ListeningSession>
+  foobazbar?: Maybe<Scalars['String']>
 }
 
 export interface Queue {
@@ -282,7 +290,19 @@ export type QueryResolvers<
     ContextType,
     RequireFields<QueryListeningSessionArgs, 'sessionId'>
   >
-  queue?: Resolver<Maybe<ResolversTypes['Queue']>, ParentType, ContextType, RequireFields<QueryQueueArgs, 'sessionId'>>
+  sessionQueue?: Resolver<
+    Array<ResolversTypes['Queue']>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerySessionQueueArgs, 'sessionId'>
+  >
+  partyRockers?: Resolver<Array<ResolversTypes['PartyRocker']>, ParentType, ContextType>
+  song?: Resolver<
+    Array<Maybe<ResolversTypes['Song']>>,
+    ParentType,
+    ContextType,
+    RequireFields<QuerySongArgs, 'songName'>
+  >
 }
 
 export type MutationResolvers<
@@ -358,6 +378,7 @@ export type ListeningSessionResolvers<
   timeCreated?: Resolver<ResolversTypes['Int'], ParentType, ContextType>
   owner?: Resolver<ResolversTypes['PartyRocker'], ParentType, ContextType>
   partyRockers?: Resolver<Array<ResolversTypes['PartyRocker']>, ParentType, ContextType>
+  queue?: Resolver<Maybe<Array<ResolversTypes['Queue']>>, ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType>
 }
 
@@ -369,6 +390,7 @@ export type PartyRockerResolvers<
   name?: Resolver<ResolversTypes['String'], ParentType, ContextType>
   spotifyCreds?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   listeningSession?: Resolver<Maybe<ResolversTypes['ListeningSession']>, ParentType, ContextType>
+  foobazbar?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>
   __isTypeOf?: IsTypeOfResolverFn<ParentType>
 }
 

--- a/server/src/graphql/schema.types.ts
+++ b/server/src/graphql/schema.types.ts
@@ -21,7 +21,8 @@ export interface Query {
   listeningSession?: Maybe<ListeningSession>
   sessionQueue: Array<Queue>
   partyRockers: Array<PartyRocker>
-  song: Array<Maybe<Song>>
+  song: Array<Song>
+  songs: Array<Song>
 }
 
 export interface QuerySurveyArgs {
@@ -297,12 +298,8 @@ export type QueryResolvers<
     RequireFields<QuerySessionQueueArgs, 'sessionId'>
   >
   partyRockers?: Resolver<Array<ResolversTypes['PartyRocker']>, ParentType, ContextType>
-  song?: Resolver<
-    Array<Maybe<ResolversTypes['Song']>>,
-    ParentType,
-    ContextType,
-    RequireFields<QuerySongArgs, 'songName'>
-  >
+  song?: Resolver<Array<ResolversTypes['Song']>, ParentType, ContextType, RequireFields<QuerySongArgs, 'songName'>>
+  songs?: Resolver<Array<ResolversTypes['Song']>, ParentType, ContextType>
 }
 
 export type MutationResolvers<

--- a/web/src/graphql/query.gen.ts
+++ b/web/src/graphql/query.gen.ts
@@ -24,6 +24,162 @@ export interface FetchUserContext {
 // This file was automatically generated and should not be edited.
 
 // ====================================================
+// GraphQL query operation: FetchListeningSession
+// ====================================================
+
+export interface FetchListeningSession_listeningSession_owner_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface FetchListeningSession_listeningSession_owner {
+  __typename: "PartyRocker";
+  id: number;
+  name: string;
+  spotifyCreds: string | null;
+  listeningSession: FetchListeningSession_listeningSession_owner_listeningSession | null;
+}
+
+export interface FetchListeningSession_listeningSession_partyRockers_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface FetchListeningSession_listeningSession_partyRockers {
+  __typename: "PartyRocker";
+  id: number;
+  name: string;
+  spotifyCreds: string | null;
+  listeningSession: FetchListeningSession_listeningSession_partyRockers_listeningSession | null;
+}
+
+export interface FetchListeningSession_listeningSession_queue_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface FetchListeningSession_listeningSession_queue {
+  __typename: "Queue";
+  id: number;
+  score: number;
+  position: number;
+  listeningSession: FetchListeningSession_listeningSession_queue_listeningSession;
+}
+
+export interface FetchListeningSession_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+  timeCreated: number;
+  owner: FetchListeningSession_listeningSession_owner;
+  partyRockers: FetchListeningSession_listeningSession_partyRockers[];
+  queue: FetchListeningSession_listeningSession_queue[] | null;
+}
+
+export interface FetchListeningSession {
+  listeningSession: FetchListeningSession_listeningSession | null;
+}
+
+export interface FetchListeningSessionVariables {
+  sessionId: number;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: FetchPartyRocker
+// ====================================================
+
+export interface FetchPartyRocker_partyRockers_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface FetchPartyRocker_partyRockers {
+  __typename: "PartyRocker";
+  id: number;
+  name: string;
+  spotifyCreds: string | null;
+  listeningSession: FetchPartyRocker_partyRockers_listeningSession | null;
+}
+
+export interface FetchPartyRocker {
+  partyRockers: FetchPartyRocker_partyRockers[];
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: FetchQueue
+// ====================================================
+
+export interface FetchQueue_listeningSession_owner_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface FetchQueue_listeningSession_owner {
+  __typename: "PartyRocker";
+  id: number;
+  name: string;
+  spotifyCreds: string | null;
+  listeningSession: FetchQueue_listeningSession_owner_listeningSession | null;
+}
+
+export interface FetchQueue_listeningSession_partyRockers_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface FetchQueue_listeningSession_partyRockers {
+  __typename: "PartyRocker";
+  id: number;
+  name: string;
+  spotifyCreds: string | null;
+  listeningSession: FetchQueue_listeningSession_partyRockers_listeningSession | null;
+}
+
+export interface FetchQueue_listeningSession_queue_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface FetchQueue_listeningSession_queue {
+  __typename: "Queue";
+  id: number;
+  score: number;
+  position: number;
+  listeningSession: FetchQueue_listeningSession_queue_listeningSession;
+}
+
+export interface FetchQueue_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+  timeCreated: number;
+  owner: FetchQueue_listeningSession_owner;
+  partyRockers: FetchQueue_listeningSession_partyRockers[];
+  queue: FetchQueue_listeningSession_queue[] | null;
+}
+
+export interface FetchQueue {
+  listeningSession: FetchQueue_listeningSession | null;
+}
+
+export interface FetchQueueVariables {
+  sessionId: number;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
 // GraphQL query operation: FetchSurveys
 // ====================================================
 
@@ -185,6 +341,107 @@ export interface NextSurveyQuestion {
 
 export interface NextSurveyQuestionVariables {
   surveyId: number;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: ListeningSession
+// ====================================================
+
+export interface ListeningSession_owner_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface ListeningSession_owner {
+  __typename: "PartyRocker";
+  id: number;
+  name: string;
+  spotifyCreds: string | null;
+  listeningSession: ListeningSession_owner_listeningSession | null;
+}
+
+export interface ListeningSession_partyRockers_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface ListeningSession_partyRockers {
+  __typename: "PartyRocker";
+  id: number;
+  name: string;
+  spotifyCreds: string | null;
+  listeningSession: ListeningSession_partyRockers_listeningSession | null;
+}
+
+export interface ListeningSession_queue_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface ListeningSession_queue {
+  __typename: "Queue";
+  id: number;
+  score: number;
+  position: number;
+  listeningSession: ListeningSession_queue_listeningSession;
+}
+
+export interface ListeningSession {
+  __typename: "ListeningSession";
+  id: number;
+  timeCreated: number;
+  owner: ListeningSession_owner;
+  partyRockers: ListeningSession_partyRockers[];
+  queue: ListeningSession_queue[] | null;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: PartyRocker
+// ====================================================
+
+export interface PartyRocker_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface PartyRocker {
+  __typename: "PartyRocker";
+  id: number;
+  name: string;
+  spotifyCreds: string | null;
+  listeningSession: PartyRocker_listeningSession | null;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: Queue
+// ====================================================
+
+export interface Queue_listeningSession {
+  __typename: "ListeningSession";
+  id: number;
+}
+
+export interface Queue {
+  __typename: "Queue";
+  id: number;
+  score: number;
+  position: number;
+  listeningSession: Queue_listeningSession;
 }
 
 /* tslint:disable */

--- a/web/src/view/playground/Surveys.tsx
+++ b/web/src/view/playground/Surveys.tsx
@@ -5,8 +5,6 @@ import { Fragment, useContext, useEffect, useState } from 'react'
 import { strutil } from '../../../../common/src/util'
 import { getApolloClient } from '../../graphql/apolloClient'
 import {
-  FetchQueue,
-  FetchQueueVariables,
   FetchSurvey,
   FetchSurveys,
   FetchSurveyVariables,
@@ -25,7 +23,6 @@ import { link } from '../nav/Link'
 import { getSurveyPath } from '../nav/route'
 import { handleError } from '../toast/error'
 import { toast } from '../toast/toast'
-import { fetchQueue } from './fetchQueue'
 import { fetchSurvey, fetchSurveys, subscribeSurveys } from './fetchSurveys'
 import { answerSurveyQuestion, nextSurveyQuestion } from './mutateSurveys'
 
@@ -66,9 +63,9 @@ export function Survey({ surveyId }: { surveyId: number }) {
     variables: { surveyId },
   })
 
-  const result= useQuery<FetchQueue, FetchQueueVariables>(fetchQueue, {
-    variables: { sessionId: 305 },
-  })
+  // const result= useQuery<FetchQueue, FetchQueueVariables>(fetchQueue, {
+  //   variables: { sessionId: 305 },
+  // })
 
   const [currQuestion, setCurrQuestion] = useState(data?.survey?.currentQuestion)
   useEffect(() => {

--- a/web/src/view/playground/Surveys.tsx
+++ b/web/src/view/playground/Surveys.tsx
@@ -5,13 +5,15 @@ import { Fragment, useContext, useEffect, useState } from 'react'
 import { strutil } from '../../../../common/src/util'
 import { getApolloClient } from '../../graphql/apolloClient'
 import {
+  FetchQueue,
+  FetchQueueVariables,
   FetchSurvey,
   FetchSurveys,
   FetchSurveyVariables,
   FetchSurvey_survey_currentQuestion,
   FetchSurvey_survey_currentQuestion_answers,
   SurveySubscription,
-  SurveySubscriptionVariables,
+  SurveySubscriptionVariables
 } from '../../graphql/query.gen'
 import { Button } from '../../style/button'
 import { H1, H2 } from '../../style/header'
@@ -23,6 +25,7 @@ import { link } from '../nav/Link'
 import { getSurveyPath } from '../nav/route'
 import { handleError } from '../toast/error'
 import { toast } from '../toast/toast'
+import { fetchQueue } from './fetchQueue'
 import { fetchSurvey, fetchSurveys, subscribeSurveys } from './fetchSurveys'
 import { answerSurveyQuestion, nextSurveyQuestion } from './mutateSurveys'
 
@@ -61,6 +64,10 @@ export function Survey({ surveyId }: { surveyId: number }) {
   const user = useContext(UserContext)
   const { loading, data, refetch } = useQuery<FetchSurvey, FetchSurveyVariables>(fetchSurvey, {
     variables: { surveyId },
+  })
+
+  const result= useQuery<FetchQueue, FetchQueueVariables>(fetchQueue, {
+    variables: { sessionId: 305 },
   })
 
   const [currQuestion, setCurrQuestion] = useState(data?.survey?.currentQuestion)

--- a/web/src/view/playground/fetchListeningSession.ts
+++ b/web/src/view/playground/fetchListeningSession.ts
@@ -1,0 +1,63 @@
+import { gql } from '@apollo/client'
+import { fragmentPartyRocker } from './fetchPartyRocker'
+import { fragmentQueue } from './fetchQueue'
+
+export const fragmentListeningSession = gql`
+  fragment ListeningSession on ListeningSession {
+    id
+    timeCreated
+    owner
+    {
+      ...PartyRocker
+    }
+    partyRockers {
+      ...PartyRocker
+    }
+    queue {
+      ...Queue
+    }
+  }
+`
+
+
+export const fetchListeningSession = gql`
+  query FetchListeningSession($sessionId: Int!) {
+    listeningSession(sessionId: $sessionId ) {
+      ...ListeningSession
+    }
+  }
+  ${fragmentListeningSession}
+  ${fragmentPartyRocker}
+  ${fragmentQueue}
+`
+
+// export const subscribeSurveys = gql`
+//   subscription SurveySubscription($surveyId: Int!) {
+//     surveyUpdates(surveyId: $surveyId) {
+//       ...Survey
+//     }
+//   }
+//   ${fragmentSurvey}
+//   ${fragmentSurveyQuestion}
+//`
+
+// export const fragmentSurveyQuestion = gql`
+//   fragment SurveyQuestion on SurveyQuestion {
+//     id
+//     prompt
+//     choices
+//     answers {
+//       answer
+//     }
+//   }
+// `
+
+// export const fetchSurvey = gql`
+//   query FetchSurvey($surveyId: Int!) {
+//     survey(surveyId: $surveyId) {
+//       ...Survey
+//     }
+//   }
+//   ${fragmentSurvey}
+//   ${fragmentSurveyQuestion}
+// `

--- a/web/src/view/playground/fetchPartyRocker.ts
+++ b/web/src/view/playground/fetchPartyRocker.ts
@@ -1,0 +1,36 @@
+import { gql } from '@apollo/client'
+
+
+// export const fragmentSurvey = gql`
+//   fragment Survey on Survey {
+//     id
+//     name
+//     isStarted
+//     isCompleted
+//     currentQuestion {
+//       ...SurveyQuestion
+//     }
+//   }
+// `
+
+export const fragmentPartyRocker = gql`
+  fragment PartyRocker on PartyRocker {
+    id
+    name
+    spotifyCreds
+    listeningSession {
+      id
+    }
+  }
+`
+
+export const fetchPartyRocker = gql`
+  query FetchPartyRocker {
+    partyRockers {
+      ...PartyRocker
+    }
+  }
+  ${fragmentPartyRocker}
+
+
+`

--- a/web/src/view/playground/fetchQueue.ts
+++ b/web/src/view/playground/fetchQueue.ts
@@ -1,0 +1,58 @@
+import { gql } from '@apollo/client'
+import { fragmentListeningSession } from './fetchListeningSession'
+import { fragmentPartyRocker } from './fetchPartyRocker'
+
+export const fragmentQueue = gql`
+  fragment Queue on Queue {
+    id
+    score
+    position
+
+    listeningSession {
+      id
+    }
+
+  }
+`
+
+
+export const fetchQueue = gql`
+  query FetchQueue($sessionId: Int!) {
+    listeningSession(sessionId: $sessionId ) {
+      ...ListeningSession
+    }
+  }
+  ${fragmentListeningSession}
+  ${fragmentPartyRocker}
+`
+
+// export const subscribeSurveys = gql`
+//   subscription SurveySubscription($surveyId: Int!) {
+//     surveyUpdates(surveyId: $surveyId) {
+//       ...Survey
+//     }
+//   }
+//   ${fragmentSurvey}
+//   ${fragmentSurveyQuestion}
+//`
+
+// export const fragmentSurveyQuestion = gql`
+//   fragment SurveyQuestion on SurveyQuestion {
+//     id
+//     prompt
+//     choices
+//     answers {
+//       answer
+//     }
+//   }
+// `
+
+// export const fetchSurvey = gql`
+//   query FetchSurvey($surveyId: Int!) {
+//     survey(surveyId: $surveyId) {
+//       ...Survey
+//     }
+//   }
+//   ${fragmentSurvey}
+//   ${fragmentSurveyQuestion}
+// `

--- a/web/src/view/playground/fetchSong.ts
+++ b/web/src/view/playground/fetchSong.ts
@@ -1,0 +1,45 @@
+import { gql } from '@apollo/client'
+
+
+// export const fragmentSurvey = gql`
+//   fragment Survey on Survey {
+//     id
+//     name
+//     isStarted
+//     isCompleted
+//     currentQuestion {
+//       ...SurveyQuestion
+//     }
+//   }
+// `
+
+export const fragmentSong = gql`
+  fragment Song on Song {
+    id
+    name
+    genre
+    duration
+    artist {
+      name
+    }
+  }
+`
+
+export const fetchSongs = gql`
+  query FetchSongs {
+    songs {
+      ...Song
+    }
+  }
+  ${fragmentSong}
+`
+
+
+export const fetchSong = gql`
+  query FetchSong($songName: String!) {
+    song(songName: $songName){
+      ...Song
+    }
+  }
+  ${fragmentSong}
+`


### PR DESCRIPTION
Accidentally merged to main gotta merge to develop. Here is the message: Dylan and Arpi Working together: Added queues in graphql schema, api.ts for listening session, songs, song, partyRockers, sessionQueue. Added gql queries in playground folder for previously mentioned entities (except for fetchSongs)